### PR TITLE
Fix typo causing startup crash

### DIFF
--- a/routes/api/electrum/servers.js
+++ b/routes/api/electrum/servers.js
@@ -91,7 +91,7 @@ module.exports = (api) => {
       list = api.electrumServers;
     }
 
-    _fs.access(api.agamaDir, api.fs.constants.R_OK, (err) => {
+    _fs.access(api.agamaDir, fs.constants.R_OK, (err) => {
       if (!err) {
         const FixFilePermissions = () => {
           return new Promise((resolve, reject) => {


### PR DESCRIPTION
After enabling custom electrum servers, app crashes upon startup.